### PR TITLE
Using GoString() and Format() to enable custom formatting

### DIFF
--- a/reuse/customfmt/customfmt.go
+++ b/reuse/customfmt/customfmt.go
@@ -31,3 +31,21 @@ func (b Building) GoString() string {
 		b.TotalArea,
 		b.NumberOfFloors)
 }
+
+// https://github.com/golang/go/issues/51195
+
+type Help struct {
+	Cmd string
+}
+
+func (h Help) Format(s fmt.State, r rune) {
+	switch r {
+	case 'h':
+		fmt.Fprintf(s, "Help yourself: %s", h.Cmd)
+	case 'm':
+		fmt.Fprintf(s, "Maybe: %s", h.Cmd)
+	default:
+		fmtDir := fmt.FormatString(s, r)
+		fmt.Fprintf(s, fmtDir, h.Cmd)
+	}
+}

--- a/reuse/customfmt/customfmt.go
+++ b/reuse/customfmt/customfmt.go
@@ -1,0 +1,33 @@
+package customfmt
+
+import (
+	"fmt"
+)
+
+type Address struct {
+	ZipCode string
+	City    string
+	Street  string
+}
+
+type Building struct {
+	TotalArea      float32
+	NumberOfFloors int
+	Addr           *Address
+}
+
+func (b Building) GoString() string {
+	if b.Addr != nil {
+		addrStr := fmt.Sprintf("Address: zip code %s, city %s, street %s",
+			b.Addr.ZipCode,
+			b.Addr.City,
+			b.Addr.Street)
+		return fmt.Sprintf("Total area %.1f sq.m., number of floors %d, %s",
+			b.TotalArea,
+			b.NumberOfFloors,
+			addrStr)
+	}
+	return fmt.Sprintf("Total area %f sq.m., number of floors %d",
+		b.TotalArea,
+		b.NumberOfFloors)
+}

--- a/reuse/customfmt/customfmt_test.go
+++ b/reuse/customfmt/customfmt_test.go
@@ -1,0 +1,35 @@
+package customfmt
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGoString(t *testing.T) {
+
+	tests := []struct {
+		input  Building
+		output string
+	}{
+		{
+			input: Building{
+				TotalArea:      1000,
+				NumberOfFloors: 4,
+				Addr: &Address{
+					ZipCode: "12345",
+					City:    "Dubuque, Iowa",
+					Street:  "2194 Bennett St",
+				},
+			},
+			output: "Total area 1000.0 sq.m., number of floors 4, Address: zip code 12345, city Dubuque, Iowa, street 2194 Bennett St",
+		},
+	}
+
+	for _, tc := range tests {
+		// The GoString method is used to print values passed as an operand to a %#v format.
+		if output := fmt.Sprintf("%#v", tc.input); output != tc.output {
+			t.Errorf("get\n%s\nexpect\n%s\n", output, tc.output)
+		}
+	}
+
+}

--- a/reuse/customfmt/customfmt_test.go
+++ b/reuse/customfmt/customfmt_test.go
@@ -33,3 +33,35 @@ func TestGoString(t *testing.T) {
 	}
 
 }
+
+func TestFormatter(t *testing.T) {
+
+	tests := []struct {
+		input  Help
+		fmtStr string
+		output string
+	}{
+		{
+			input:  Help{"run"},
+			fmtStr: "%h",
+			output: "Help yourself: run",
+		},
+		{
+			input:  Help{"run"},
+			fmtStr: "%m",
+			output: "Maybe: run",
+		},
+		{
+			input:  Help{"run"},
+			fmtStr: "%s",
+			output: "run",
+		},
+	}
+
+	for _, tc := range tests {
+		if output := fmt.Sprintf(tc.fmtStr, tc.input); output != tc.output {
+			t.Errorf("get\n%s\nexpect\n%s\n", output, tc.output)
+		}
+	}
+
+}


### PR DESCRIPTION
Closes #1 

Adds example implementations of `GoStringer` and `Formatter` interfaces.
